### PR TITLE
Add Adam Cameron's CFScript docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Pull requests very welcome.
 * [Railo Documentation](https://github.com/getrailo/railo/wiki) - Official Railo docs
 * [CFDocs](http://cfdocs.org/) - UltraFast CFML Documentation Reference.
 * [CFQuickDocs](http://cfquickdocs.com/) - ColdFusion documentation
+* [CFScript Reference](https://github.com/daccfml/cfscript/blob/master/cfscript.md) -  CFScript Documentation by Adam Cameron


### PR DESCRIPTION
I was a bit torn as to whether it should be in References or Documentation but it is pretty thorough and well put together so I think it's suited in the Docs section. Cheers.